### PR TITLE
Avoid use of local agent keys

### DIFF
--- a/bash/bosh
+++ b/bash/bosh
@@ -89,7 +89,7 @@ bosh() {
 		;;
 
 	(*)
-		command bosh "$@"
+		SSH_AUTH_SOCK= command bosh "$@"
 		return $?
 		;;
 	esac


### PR DESCRIPTION
This helps avoid SSH failures with the message "Too many Authentication Failures" when more than one keypair is present.